### PR TITLE
Enable not extracting digests

### DIFF
--- a/rpm_head_signing/extract_header.py
+++ b/rpm_head_signing/extract_header.py
@@ -27,9 +27,10 @@ def extract_header(input_path, header_out_path, digest_out_path):
     hdr_start = sig_start + sig_size
     hdr_size = rpm_hdr_size(input_path, hdr_start)
 
-    rpm_hdr = get_rpm_header(input_path)
-    file_digestalgo, file_digests = _get_filedigests(rpm_hdr)
-    file_digests = set(file_digests)
+    if digest_out_path:
+        rpm_hdr = get_rpm_header(input_path)
+        file_digestalgo, file_digests = _get_filedigests(rpm_hdr)
+        file_digests = set(file_digests)
 
     with open(input_path, "rb") as f:
         f.seek(hdr_start)
@@ -39,12 +40,13 @@ def extract_header(input_path, header_out_path, digest_out_path):
         with open(header_out_path, "wb") as of:
             of.write(hdrcts)
 
-    with open(digest_out_path, "at") as df:
-        for digest in file_digests:
-            digest = digest.strip()
-            if not digest:
-                continue
-            df.write("%s %s\n" % (file_digestalgo, digest))
+    if digest_out_path:
+        with open(digest_out_path, "at") as df:
+            for digest in file_digests:
+                digest = digest.strip()
+                if not digest:
+                    continue
+                df.write("%s %s\n" % (file_digestalgo, digest))
 
 
 if __name__ == '__main__':

--- a/test.py
+++ b/test.py
@@ -62,6 +62,21 @@ class TestRpmHeadSigning(unittest.TestCase):
         self.compare_files("testpkg-2.noarch.rpm.hdr", "testpkg-2.noarch.rpm.hdr.tmp")
         self.compare_files("digests.out", "digests.out.tmp")
 
+    def test_extract_no_digests(self):
+        rpm_head_signing.extract_header(
+            os.path.join(self.asset_dir, 'testpkg-1.noarch.rpm'),
+            os.path.join(self.tmpdir, 'testpkg-1.noarch.rpm.hdr.tmp'),
+            digest_out_path=None,
+        )
+        rpm_head_signing.extract_header(
+            os.path.join(self.asset_dir, 'testpkg-2.noarch.rpm'),
+            os.path.join(self.tmpdir, 'testpkg-2.noarch.rpm.hdr.tmp'),
+            digest_out_path=None,
+        )
+
+        self.compare_files("testpkg-1.noarch.rpm.hdr", "testpkg-1.noarch.rpm.hdr.tmp")
+        self.compare_files("testpkg-2.noarch.rpm.hdr", "testpkg-2.noarch.rpm.hdr.tmp")
+
     def test_extract_non_hdrsign_able(self):
         with self.assertRaises(rpm_head_signing.NonHeaderSignablePackage):
             rpm_head_signing.extract_header(


### PR DESCRIPTION
Make it possible to not extract the IMA digests out of an RPM if the
caller doesn't care about that.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>