### PR TITLE
Implement return_header

### DIFF
--- a/test_insert.py
+++ b/test_insert.py
@@ -1,16 +1,36 @@
 #/usr/bin/env python
+import shutil
 import sys
+
+import koji
 
 import rpm_head_signing
 
 
-def main(rpm_path, sig_path, ima_path):
-    rpm_head_signing.insert_signature(
-        rpm_path,
-        sig_path,
-        ima_presigned_path=ima_path,
-    )
-
-
 if __name__ == '__main__':
-    main(sys.argv[1], sys.argv[2], sys.argv[3])
+    mode = sys.argv[1]
+    rpm_path = sys.argv[2]
+    sig_path = sys.argv[3]
+    ima_path = sys.argv[4]
+
+    if mode == 'normal':
+        rpm_head_signing.insert_signature(
+            rpm_path,
+            sig_path,
+            ima_presigned_path=ima_path,
+        )
+    elif mode == 'splice_header':
+        header = rpm_head_signing.insert_signature(
+            rpm_path,
+            sig_path,
+            ima_presigned_path=ima_path,
+            return_header=True,
+        )
+        header = bytes(header)
+        new_path = koji.splice_rpm_sighdr(
+            bytes(header),
+            rpm_path,
+        )
+        shutil.move(new_path, rpm_path)
+    else:
+        raise Exception("Unsupported mode %s" % mode)


### PR DESCRIPTION
This implements the return_header=True version of insertlib, which
returns the raw signed header.
This allows users to not need the full RPM rebuilt.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>