### PR TITLE
Add methods to get IMA signature info

### DIFF
--- a/rpm_head_signing/__init__.py
+++ b/rpm_head_signing/__init__.py
@@ -1,3 +1,4 @@
 from .insert_signature import insert_signature
 from .extract_header import extract_header, NonHeaderSignablePackage
 from .extract_rpm_with_filesigs import extract_rpm_with_filesigs
+from .extract_signature_and_ima_info import parse_ima_signature, get_rpm_ima_signature_info

--- a/rpm_head_signing/extract_signature_and_ima_info.py
+++ b/rpm_head_signing/extract_signature_and_ima_info.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+import binascii
+import struct
+
+from cryptography.hazmat.primitives.asymmetric.utils import Prehashed
+import cryptography.hazmat.primitives.hashes as crypto_hashes
+import cryptography.hazmat.primitives.asymmetric.ec as crypto_ec
+
+from .extract_rpm_with_filesigs import _extract_filesigs
+
+
+def parse_ima_signature(sig):
+    if not isinstance(sig, bytearray):
+        sig = bytearray(sig)
+
+    if len(sig) < 10:
+        return None
+
+    info = {
+        'type': sig[0],
+        'version': sig[1],
+        'alg_id': sig[2],
+        'key_id': bytes(sig[3:7]),
+        'sig_size': struct.unpack('>H', sig[7:9])[0],
+
+        'error': 'Did not finish parsing',
+    }
+
+    readable_key_id = binascii.hexlify(sig[3:7])
+    if not isinstance(readable_key_id, str):
+        readable_key_id = readable_key_id.decode('utf8')
+    info['user_readable_key_id'] = readable_key_id
+
+    if info['type'] != 3:
+        info['error'] = 'Unsupported type'
+        return info
+    if info['version'] != 2:
+        info['error'] = 'Unsupported version'
+        return info
+
+    if info['alg_id'] == 7:  # SHA224
+        info['alg_name'] = 'SHA224'
+        crypto_algo = crypto_hashes.SHA224()
+    elif info['alg_id'] == 4:  # SHA256
+        info['alg_name'] = 'SHA256'
+        crypto_algo = crypto_hashes.SHA256()
+    elif info['alg_id'] == 5:  # SHA384
+        info['alg_name'] = 'SHA384'
+        crypto_algo = crypto_hashes.SHA384()
+    elif info['alg_id'] == 6:  # SHA512
+        info['alg_name'] = 'SHA512'
+        crypto_algo = crypto_hashes.SHA512()
+    else:
+        info['error'] = 'Unsupported algorithm %d' % info['alg_id']
+        return info
+    info['hashing_algorithm'] = crypto_algo
+    crypto_algo = Prehashed(crypto_algo)
+    info['algorithm'] = crypto_ec.ECDSA(crypto_algo)
+
+    if (len(sig) - 9) != info['sig_size']:
+        info['error'] = 'Signature length mismatch: %d (actual) != %d (expected)' % (len(sig) - 9, info['sig_size'])
+        return info
+
+    info['signature'] = bytes(sig[9:])
+    info['error'] = None
+
+    return info
+
+
+def get_rpm_ima_signature_info(rpm_path):
+    signatures = _extract_filesigs(rpm_path)
+    if signatures is None:
+        return None
+    siginfos = {}
+    for path in signatures:
+        siginfos[path] = parse_ima_signature(signatures[path])
+    return siginfos

--- a/test.py
+++ b/test.py
@@ -140,6 +140,8 @@ class TestRpmHeadSigning(unittest.TestCase):
         self._test_insert_ima_valgrind('splice_header')
 
     def _test_insert_ima_valgrind(self, insert_mode):
+        if os.environ.get('SKIP_VALGRIND'):
+            raise unittest.SkipTest('Valgrind tests are disabled')
         valgrind_logfile = os.environ.get(
             'VALGRIND_LOG_FILE',
             '%s/valgrind.log' % self.tmpdir,

--- a/test.py
+++ b/test.py
@@ -215,6 +215,19 @@ class TestRpmHeadSigning(unittest.TestCase):
             self.assertTrue(b'Header V3 RSA' in res)
             self.assertTrue(b'15f712be: ok' in res.lower())
 
+            siginfos = rpm_head_signing.get_rpm_ima_signature_info(
+                os.path.join(self.tmpdir, 'testpkg-%s.noarch.rpm' % pkg),
+            )
+            if siginfos is None:
+                raise Exception("No IMA signatures found")
+            CORRECT_KEY_ID = '379efb19'
+            for path in siginfos:
+                siginfo = siginfos[path]
+                if siginfo['error']:
+                    raise Exception("Siginfo parsing for path %s resulted in error: %s" % (path, siginfo['error']))
+                if siginfo['user_readable_key_id'] != CORRECT_KEY_ID:
+                    raise Exception("User readable key ID is %s, not %s" % (siginfo['user_readable_key_id'], CORRECT_KEY_ID))
+
             extracted_dir = os.path.join(self.tmpdir, 'testpkg-%s.noarch.extracted' % pkg)
 
             os.mkdir(extracted_dir)
@@ -258,55 +271,43 @@ def alternative_evmctl_check(file_path, pubkey):
     # In RHEL7, evmctl is too old, so we won't be able to run the
     #  evmctl check
     ima_sig = bytearray(xattr.getxattr(file_path, 'user.ima'))
-    if ima_sig[0] != 3:
-        raise Exception("IMA signature has wrong prefix (%s)" % ima_sig[0])
-    if ima_sig[1] != 2:
-        raise Exception("IMA signature has wrong version (%s)" % ima_sig[1])
-    algo_id = ima_sig[2]
-    if algo_id == 7:  # SHA224
-        hasher = hashlib.sha224()
-        crypto_algo = crypto_hashes.SHA224()
-    elif algo_id == 4:  # SHA256
-        hasher = hashlib.sha256()
-        crypto_algo = crypto_hashes.SHA256()
-    elif algo_id == 5:  # SHA384
-        hasher = hashlib.sha384()
-        crypto_algo = crypto_hashes.SHA384()
-    elif algo_id == 6:  # SHA512
-        hasher = hashlib.sha512()
-        crypto_algo = crypto_hashes.SHA512()
-    else:
-        raise Exception("IMA signature has invalid algo: %d" % algo_id)
-    crypto_algo = Prehashed(crypto_algo)
+    ima_sig_info = rpm_head_signing.parse_ima_signature(ima_sig)
+    if ima_sig_info['error']:
+        raise Exception("Error parsing IMA signature: %s" % ima_sig_info['error'])
+    if ima_sig_info['type'] != 3:
+        raise Exception("IMA signature has wrong prefix (%s)" % ima_sig_info['type'])
+    if ima_sig_info['version'] != 2:
+        raise Exception("IMA signature has wrong version (%s)" % ima_sig_info['version'])
     if sys.version_info.major == 3:
         # X962 is only supported on Cryptography 2.5+
         # We are a bit lazy and just check for py3 instead of checking this more carefully
 
         # Check the Key ID
-        key_id = ima_sig[3:7]
         keybytes = pubkey.public_bytes(
             crypto_serialization.Encoding.X962,
             crypto_serialization.PublicFormat.UncompressedPoint,
         )
-        keybytes_digester = Hash(SHA1())
+        keybytes_digester = Hash(
+            SHA1(),
+            backend=default_backend(),
+        )
         keybytes_digester.update(keybytes)
         keybytes_digest = keybytes_digester.finalize()
         correct_keyid = keybytes_digest[-4:]
-        if correct_keyid != key_id:
-            raise Exception("IMA signature has invalid key ID: %s != %s" % (correct_keyid, key_id))
+        if correct_keyid != ima_sig_info['key_id']:
+            raise Exception("IMA signature has invalid key ID: %s != %s" % (correct_keyid, ima_sig_info['key_id']))
     # Check the signature itself
-    (sig_size,) = struct.unpack('>H', ima_sig[7:9])
-    sig = ima_sig[9:]
-    if len(sig) != sig_size:
-        raise Exception("IMA signature size invalid: %d != %d" % (len(sig), sig_size))
-
+    hasher = Hash(
+        ima_sig_info['hashing_algorithm'],
+        backend=default_backend(),
+    )
     with open(file_path, 'rb') as f:
         hasher.update(f.read())
-        file_digest = hasher.digest()
+        file_digest = hasher.finalize()
     pubkey.verify(
-        bytes(sig),
+        ima_sig_info['signature'],
         bytes(file_digest),
-        crypto_ec.ECDSA(crypto_algo),
+        ima_sig_info['algorithm'],
     )
 
 


### PR DESCRIPTION
This makes it easy for external users to extract the IMA signature
information when they have a use for it.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>