### PR TITLE
Fix handling errors before sigtd is set

### DIFF
--- a/rpm_head_signing/insertlib.c
+++ b/rpm_head_signing/insertlib.c
@@ -481,7 +481,7 @@ out:
     free(trpm);
     free(msg);
 #ifdef RPM_411
-    if (sigtd->data != NULL) free(sigtd->data);
+    if (sigtd != NULL && sigtd->data != NULL) free(sigtd->data);
 #endif
     if (sigtd != NULL) rpmtdFree(sigtd);
 


### PR DESCRIPTION
If we error out before sigtd is created on RPM 4.11, we risk a segfault
because sigtd will be NULL.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>