### PR TITLE
Fix compile on f32

### DIFF
--- a/rpm_head_signing/insertlib.c
+++ b/rpm_head_signing/insertlib.c
@@ -16,6 +16,9 @@ int rpmWriteSignature(FD_t fd, Header sigh);
 
 #if defined(RPM_415)
 
+    // There are 4.15 versions that don't have this define
+    #define RPMTAG_PAYLOADDIGESTALT 5097
+
     rpmRC rpmLeadRead(FD_t fd, char **emsg);
     rpmRC rpmLeadWrite(FD_t fd, Header h);
     rpmRC rpmReadSignature(FD_t fd, Header * sighp, char ** msg);


### PR DESCRIPTION
It seems that PAYLOADDIGESTALT was added in a 4.15 intermediate release,
so let's just define it ourselves.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>