### PR TITLE
Use packit for package maintaining

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -3,6 +3,8 @@ specfile_path: python-rpm-head-signing.spec
 synced_files:
     - python-rpm-head-signing.spec
     - .packit.yaml
+create_pr: false
+sync_changelog: true
 
 upstream_package_name: rpm-head-signing
 upstream_project_url: https://github.com/fedora-iot/rpm-head-signing
@@ -19,3 +21,6 @@ jobs:
       - fedora-all
       - epel-7-x86_64
       - epel-8-x86_64
+- job: propose_downstream
+  trigger: release
+


### PR DESCRIPTION
This uses Packit to directly push to dist-git and take our changelog.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>