### PR TITLE
Add a console script for verify-rpm

### DIFF
--- a/python-rpm-head-signing.spec
+++ b/python-rpm-head-signing.spec
@@ -139,6 +139,7 @@ PYTHONPATH=%{buildroot}%{python3_sitearch} SKIP_IMA_LIVE_CHECK=true python3 test
 %license LICENSE
 %{python2_sitearch}/%{srcname}/
 %{python2_sitearch}/%{srcname}-%{version}-py%{python2_version}.egg-info/
+%{_bindir}/verify-rpm-ima-signatures
 %endif
 
 %if %{with python3}
@@ -146,6 +147,7 @@ PYTHONPATH=%{buildroot}%{python3_sitearch} SKIP_IMA_LIVE_CHECK=true python3 test
 %license LICENSE
 %{python3_sitearch}/%{srcname}/
 %{python3_sitearch}/%{srcname}-%{version}-py%{python3_version}.egg-info/
+%{_bindir}/verify-rpm-ima-signatures
 %endif
 
 

--- a/rpm_head_signing/verify_rpm.py
+++ b/rpm_head_signing/verify_rpm.py
@@ -191,7 +191,7 @@ def manual_sigcheck(file_path, correct_keyid, pubkey):
     )
 
 
-if __name__ == "__main__":
+def __main__():
     args = get_args().parse_args()
     if args.debug:
         logging.basicConfig(level=logging.DEBUG)
@@ -199,3 +199,7 @@ if __name__ == "__main__":
         logging.basicConfig(level=logging.INFO)
     if not main(args):
         raise Exception("At least one exception was thrown during validation")
+
+
+if __name__ == "__main__":
+    __main__()

--- a/setup.py
+++ b/setup.py
@@ -38,4 +38,9 @@ setup(
         "rpm",
         "pyxattr",
     ],
+    entry_points={
+        "console_scripts": [
+            "verify-rpm-ima-signatures=rpm_head_signing.verify_rpm:__main__",
+        ],
+    },
 )

--- a/test.py
+++ b/test.py
@@ -7,7 +7,7 @@ import sys
 import unittest
 
 import rpm_head_signing
-import verify_rpm
+import rpm_head_signing.verify_rpm
 
 
 class TestRpmHeadSigning(unittest.TestCase):
@@ -179,8 +179,8 @@ class TestRpmHeadSigning(unittest.TestCase):
         args = self._get_verify_rpm_args()
         args.extend([os.path.join(self.asset_dir, "testpkg-1.rpm")])
 
-        args = verify_rpm.get_args().parse_args(args)
-        self.assertFalse(verify_rpm.main(args))
+        args = rpm_head_signing.verify_rpm.get_args().parse_args(args)
+        self.assertFalse(rpm_head_signing.verify_rpm.main(args))
 
     def test_insert_ima_valgrind_normal(self):
         self._test_insert_ima_valgrind("normal", "15f712be")
@@ -305,8 +305,8 @@ class TestRpmHeadSigning(unittest.TestCase):
         args = self._get_verify_rpm_args()
         args.extend(rpm_paths)
 
-        args = verify_rpm.get_args().parse_args(args)
-        self.assertTrue(verify_rpm.main(args))
+        args = rpm_head_signing.verify_rpm.get_args().parse_args(args)
+        self.assertTrue(rpm_head_signing.verify_rpm.main(args))
 
     def _get_verify_rpm_args(self):
         args = []


### PR DESCRIPTION
This makes it possible to use the verification script from the console.

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>