### PR TITLE
Skip symbolic links for IMA signature verification

### DIFF
--- a/rpm_head_signing/extract_rpm_with_filesigs.py
+++ b/rpm_head_signing/extract_rpm_with_filesigs.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from tempfile import TemporaryFile
+import logging
 import subprocess
 import os.path
 import sys
@@ -123,7 +124,11 @@ def _extract_filesigs(rpm_path):
 def _install_filesigs(signatures, output_path):
     for path in signatures:
         full_path = os.path.join(output_path, path.lstrip("/"))
-        xattr.setxattr(full_path, "user.ima", bytes(signatures[path]))
+        if os.path.islink(full_path):
+            logging.debug("Skipping symbolic link at %s", path)
+        else:
+            logging.debug("Installing signature for %s", path)
+            xattr.setxattr(full_path, "user.ima", bytes(signatures[path]))
 
 
 def extract_rpm_with_filesigs(rpm_path, output_path):

--- a/rpm_head_signing/verify_rpm.py
+++ b/rpm_head_signing/verify_rpm.py
@@ -119,6 +119,9 @@ def main(args):
             for (where, _, fnames) in os.walk(extracted_dir):
                 for fname in fnames:
                     file_path = os.path.join(where, fname)
+                    if os.path.islink(file_path):
+                        logging.debug("Skipping symbolic link at %s", file_path)
+                        continue
                     logging.debug("Verifying file %s ...", file_path)
 
                     if not args.skip_evmctl:


### PR DESCRIPTION
Symbolic links require privileged execution in order to create their
extended attributes, see xattr(7).

Signed-off-by: Patrick Uiterwijk <patrick@puiterwijk.org>