### PR TITLE
don't unnessarily include script headers

### DIFF
--- a/rpm_head_signing/extract_header.py
+++ b/rpm_head_signing/extract_header.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import rpm
 from koji import (
     RawHeader,

--- a/rpm_head_signing/extract_rpm_with_filesigs.py
+++ b/rpm_head_signing/extract_rpm_with_filesigs.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from tempfile import TemporaryFile
 import logging
 import subprocess

--- a/rpm_head_signing/extract_signature_and_ima_info.py
+++ b/rpm_head_signing/extract_signature_and_ima_info.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import binascii
 import struct
 

--- a/rpm_head_signing/insert_signature.py
+++ b/rpm_head_signing/insert_signature.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import base64
 import binascii
 import struct

--- a/rpm_head_signing/verify_rpm.py
+++ b/rpm_head_signing/verify_rpm.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 import argparse
 from tempfile import mkdtemp
 import logging


### PR DESCRIPTION
These python files aren't run as scripts directly so don't include the script headers as they're not directly necessary and rpm packaging complains.