### PR TITLE
Add sentinel to InsertLibMethods

### DIFF
--- a/rpm_head_signing/insertlib.c
+++ b/rpm_head_signing/insertlib.c
@@ -778,6 +778,7 @@ out:
 static PyMethodDef InsertLibMethods[] = {
     {"insert_signatures", insert_signatures, METH_VARARGS, "Insert signatures into an RPM"},
     {"fix_ima_signatures", fix_ima_signatures, METH_VARARGS, "Fix IMA signatures in an RPM"},
+    {NULL, NULL, 0, NULL},
 };
 
 #if PY_MAJOR_VERSION == 2


### PR DESCRIPTION
The sentinel in InsertLibMethods becomes critical with an optimised build of insertlib, since otherwise it tries to read whatever's next in the file as a string.

Add the sentinel so that this bug (which manifests as a segfault on import) doesn't occur.