### PR TITLE
Add dependencies in setup.py

### DIFF
--- a/python-rpm-head-signing.spec
+++ b/python-rpm-head-signing.spec
@@ -83,6 +83,7 @@ Summary:        %{summary}
 
 %if %{undefined python_enable_dependency_generator} && %{undefined python_disable_dependency_generator}
 # Put manual requires here:
+Requires:       python%{python3_pkgversion}-cryptography
 Requires:       python%{python3_pkgversion}-koji
 Requires:       python%{python3_pkgversion}-six
 Requires:       python%{python3_pkgversion}-xattr

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,14 @@ elif rpm_version[1] == 11:
 else:
     raise Exception("Unsupported RPM version %s" % rpm_version)
 
+requires = [
+    "cryptography",
+    "koji",
+    "six",
+    "xattr",
+    "rpm",
+]
+
 insertlib = Extension(
     "insertlib",
     libraries=["rpm", "rpmio"],
@@ -30,6 +38,7 @@ setup(
     name="rpm_head_signing",
     version="1.7.2",
     packages=["rpm_head_signing"],
+    install_requires=requires,
     ext_package="rpm_head_signing",
     ext_modules=[insertlib],
     entry_points={


### PR DESCRIPTION
Currently, Fedora's automatic Python run-time dependency generator fails to generate dependencies because it uses package metadata (as recorded in installed *.dist-info directories) to determine what the package depends on [1]. Add dependencies in setup.py so dependencies can be contained in *.dist-info.

Note this package also depends on cryptography. Add this missing dependency as well.

[1] https://docs.fedoraproject.org/en-US/packaging-guidelines/Python/#_run_time_dependency_generator