### PR TITLE
ci: run ci tests on centos stream 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,23 @@ jobs:
 
       - name: Run tests
         run: PRINT_VALGRIND_LOG=1 python3 test.py
+
+  tests_centos_9:
+    runs-on: ubuntu-latest
+    container: quay.io/centos/centos:stream9
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install deps
+        run: |
+          dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+          crb enable
+          dnf install -y python3-koji python3-rpm make gcc rpm-sign cpio python3-setuptools rpm-devel python3-devel python3-cryptography valgrind python3-pyxattr crypto-policies-scripts
+          update-crypto-policies --set DEFAULT:SHA1
+
+      - name: Build insertlib
+        run: |
+          python3 setup.py build_ext -i
+
+      - name: Run tests
+        run: PRINT_VALGRIND_LOG=1 python3 test.py

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -22,9 +22,6 @@ jobs:
       - epel-9-x86_64
       - epel-8-x86_64
 
-- job: propose_downstream
-  trigger: release
-
 - job: sync_from_downstream
   trigger: commit
 


### PR DESCRIPTION
Users are running this on el9 so we should be running CI on centos stream9 to ensure we don't regress there too.