### PR TITLE
Drop unneeded dependency six

### DIFF
--- a/python-rpm-head-signing.spec
+++ b/python-rpm-head-signing.spec
@@ -85,7 +85,6 @@ Summary:        %{summary}
 # Put manual requires here:
 Requires:       python%{python3_pkgversion}-cryptography
 Requires:       python%{python3_pkgversion}-koji
-Requires:       python%{python3_pkgversion}-six
 Requires:       python%{python3_pkgversion}-xattr
 Requires:       python%{python3_pkgversion}-rpm
 %endif

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ else:
 requires = [
     "cryptography",
     "koji",
-    "six",
     "xattr",
     "rpm",
 ]


### PR DESCRIPTION
six is no longer used since commit 74743ff ("Remove dependency on six").