### PR TITLE
chore: merge fedora and upstream spec file

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,14 +1,14 @@
-specfile_path: python-rpm-head-signing.spec
+specfile_path: rpm-head-signing.spec
 
 synced_files:
-    - python-rpm-head-signing.spec
+    - rpm-head-signing.spec
     - .packit.yaml
 sync_changelog: true
 
 upstream_package_name: rpm-head-signing
 upstream_tag_template: v{version}
 upstream_project_url: https://github.com/fedora-iot/rpm-head-signing
-downstream_package_name: python-rpm-head-signing
+downstream_package_name: rpm-head-signing
 
 actions:
     get-current-version: 'python3 setup.py --version'

--- a/rpm-head-signing.spec
+++ b/rpm-head-signing.spec
@@ -1,10 +1,5 @@
-%if 0%{?fedora} || 0%{?rhel} >= 8
-%bcond_with python2
-%bcond_without python3
-%else
-%bcond_without python2
-%bcond_with python3
-%endif
+# Currently broken in koji
+%bcond_with tests
 
 # Without this, the resulting insertlib will segfault
 %define _lto_cflags %{nil}
@@ -14,29 +9,14 @@
 %global pkgname rpm-head-signing
 %global srcname rpm_head_signing
 
-Name:           python-rpm-head-signing
+Name:           rpm-head-signing
 Version:        1.7.2
 Release:        1%{?dist}
 Summary:        Small python module to extract RPM header and file digests
 License:        MIT
 URL:            https://github.com/fedora-iot/rpm-head-signing
-Source0:        https://github.com/fedora-iot/rpm-head-signing/archive/refs/tags/v%{version}.tar.gz
+Source0:        %url/archive/v%{version}.tar.gz#/%{name}-%{version}.tar.gz
 
-%if %{with python3}
-BuildRequires:  python%{python3_pkgversion}-devel
-BuildRequires:  python%{python3_pkgversion}-setuptools
-BuildRequires:  python%{python3_pkgversion}-koji
-BuildRequires:  python%{python3_pkgversion}-rpm
-BuildRequires:  python%{python3_pkgversion}-cryptography
-BuildRequires:  python%{python3_pkgversion}-pyxattr
-%endif
-%if %{with python2}
-BuildRequires:  python2-devel
-BuildRequires:  python2-setuptools
-BuildRequires:  python2-koji
-BuildRequires:  python2-cryptography
-BuildRequires:  pyxattr
-%endif
 BuildRequires:  gcc
 BuildRequires:  openssl-devel
 BuildRequires:  ima-evm-utils
@@ -46,56 +26,23 @@ BuildRequires:  rpm-sign
 BuildRequires:  cpio
 BuildRequires:  valgrind
 BuildRequires:  zstd
-
-%{?python_enable_dependency_generator}
-
-%description
-Python tools for signing RPMs without sending over the full RPM.
-
-
-%if %{with python2}
-%package -n python2-%{pkgname}
-Summary:        %{summary}
-%{?python_provide:%python_provide python2-%{pkgname}}
-
-%if %{undefined python_enable_dependency_generator} && %{undefined python_disable_dependency_generator}
-# Put manual requires here:
-Requires:       python2-koji
-Requires:       python2-six
-%if 0%{?fedora} || 0%{?rhel} >= 8
-Requires:       python2-pyxattr
-Requires:       rpm-python
-%else
-Requires:       pyxattr
-Requires:       rpm-python
-%endif
-%endif
-
-%description -n python2-%{pkgname}
-Python tools for signing RPMs without sending over the full RPM.
-%endif
-
-
-%if %{with python3}
-%package -n python%{python3_pkgversion}-%{pkgname}
-Summary:        %{summary}
+BuildRequires:  python%{python3_pkgversion}-devel
+BuildRequires:  python%{python3_pkgversion}-setuptools
+BuildRequires:  python%{python3_pkgversion}-koji
+BuildRequires:  python%{python3_pkgversion}-rpm
+BuildRequires:  python%{python3_pkgversion}-cryptography
+BuildRequires:  python%{python3_pkgversion}-pyxattr
 %{?python_provide:%python_provide python3-%{pkgname}}
 
-%if %{undefined python_enable_dependency_generator} && %{undefined python_disable_dependency_generator}
-# Put manual requires here:
-Requires:       python%{python3_pkgversion}-cryptography
-Requires:       python%{python3_pkgversion}-koji
-Requires:       python%{python3_pkgversion}-xattr
-Requires:       python%{python3_pkgversion}-rpm
-%endif
-
-%description -n python%{python3_pkgversion}-%{pkgname}
-Python tools for signing RPMs without sending over the full RPM.
-%endif
-
+%description
+A small Python module (with C helper) to extract a RPM header and file
+digests and reinsert the signature and signed file digests. This is
+used for when you want to retrieve the parts to sign if you have a
+remote signing server without having to transmit the entire RPM over
+to the server.
 
 %prep
-%autosetup -p1 -n rpm-head-signing-%{version}
+%autosetup -p1
 for lib in rpm_head_signing/*.py; do
  sed '1{\@^#!/usr/bin/env python@d}' $lib > $lib.new
  mv $lib.new $lib
@@ -103,52 +50,28 @@ done
 
 
 %build
-%if %{with python2}
-%py2_build
-%endif
-
-%if %{with python3}
 %py3_build
-%endif
 
 
 %install
-%if %{with python2}
-%py2_install
-%endif
-
-%if %{with python3}
 %py3_install
-%endif
 
 
+%if %{with tests}
 %check
 # To make sure we get to use the installed version
 mv rpm_head_signing rpm_head_signing.orig
 
-%if %{with python2}
-PYTHONPATH=%{buildroot}%{python2_sitearch} SKIP_BYTEORDER_CHECK=true SKIP_IMA_LIVE_CHECK=true ONLY_ALTERNATIVE_EVMCTL_CHECK=true python2 test.py
-%endif
-%if %{with python3}
 PYTHONPATH=%{buildroot}%{python3_sitearch} SKIP_IMA_LIVE_CHECK=true python3 test.py
 %endif
 
 
-%if %{with python2}
-%files -n  python2-%{pkgname}
+%files
 %license LICENSE
-%{python2_sitearch}/%{srcname}/
-%{python2_sitearch}/%{srcname}-%{version}-py%{python2_version}.egg-info/
+%doc README.md
 %{_bindir}/verify-rpm-ima-signatures
-%endif
-
-%if %{with python3}
-%files -n  python%{python3_pkgversion}-%{pkgname}
-%license LICENSE
 %{python3_sitearch}/%{srcname}/
-%{python3_sitearch}/%{srcname}-%{version}-py%{python3_version}.egg-info/
-%{_bindir}/verify-rpm-ima-signatures
-%endif
+%{python3_sitearch}/%{srcname}-*/
 
 
 %changelog


### PR DESCRIPTION
The upstream splits out things that don't really need to be, but have things the Fedora spec doesn't. Merge the two for the best of both worlds so we can use things like packit to automate as much as possible.