### PR TITLE
Update .packit.yml to support new packit release 1.0.0

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,6 +1,6 @@
 specfile_path: rpm-head-signing.spec
 
-synced_files:
+files_to_sync:
     - rpm-head-signing.spec
     - .packit.yaml
 sync_changelog: true
@@ -16,11 +16,10 @@ actions:
 jobs:
 - job: copr_build
   trigger: pull_request
-  metadata:
-    targets:
-      - fedora-all
-      - epel-9-x86_64
-      - epel-8-x86_64
+  targets:
+    - fedora-all
+    - epel-9-x86_64
+    - epel-8-x86_64
 
 - job: sync_from_downstream
   trigger: commit


### PR DESCRIPTION
Packit 1.0.0 does not support deprecated `synced_files` key anymore, `synced_files` has been substituted by [files_to_sync](https://packit.dev/docs/configuration#files_to_sync).
`metadata` is also deprecated.

More details about Packit 1.0.0 can be found [here](https://packit.dev/posts/packit_1_0_0_action_required).

**Please, merge this PR in a week. Packit CI will fail otherwise starting from next week.**

This PR substitutes https://github.com/fedora-iot/rpm-head-signing/pull/77 (which can be closed).