### PR TITLE
Fix v6 signature insertion

### DIFF
--- a/rpm_head_signing/determine.py
+++ b/rpm_head_signing/determine.py
@@ -1,4 +1,5 @@
 import rpm
+import subprocess
 from koji import (
     find_rpm_sighdr,
     rpm_hdr_size,
@@ -12,10 +13,20 @@ from .extract_rpm_with_filesigs import (
     _get_header_type_8,
 )
 
+SUPPORTS_V6_HDR = False
+rpm_version = subprocess.check_output(["rpm", "--version"])
+# Example: RPM version 4.16.90
+rpm_version = rpm_version.split(b" ")[2].split(b".")
+# Ignore the last bit, which could be e.g. 0-beta1
+rpm_version = tuple(map(int, rpm_version[:2]))
+if rpm_version[0] >= 5:
+    SUPPORTS_V6_HDR = True
+
 
 class DetermineResult(object):
     is_head_only_signable = None
     is_head_only_signed = None
+    is_head_only_v6_signed = None
     is_signed = None
     is_ima_signed = None
 
@@ -33,6 +44,10 @@ def determine_rpm_status(rpm_path):
         hdr = f.read(hdr_size)
         hdr = RawHeader(hdr)
 
+    extra_fields = ()
+    if SUPPORTS_V6_HDR:
+        extra_fields += ("openpgp",)
+
     fields = get_header_fields(
         rpm_path,
         (
@@ -42,7 +57,8 @@ def determine_rpm_status(rpm_path):
             "sigpgp",
             "rsaheader",
             "dsaheader",
-        ),
+        )
+        + extra_fields,
     )
 
     filesignatures = sighdr.index.get(RPMSIGTAG_FILESIGNATURES)
@@ -69,11 +85,18 @@ def determine_rpm_status(rpm_path):
         and fields["siggpg"] is None
         and fields["sigpgp"] is None
     )
+    if SUPPORTS_V6_HDR:
+        result.is_head_only_v6_signed = (
+            fields["openpgp"] is not None
+            and fields["siggpg"] is None
+            and fields["sigpgp"] is None
+        )
     result.is_signed = (
         fields["rsaheader"] is not None
         or fields["dsaheader"] is not None
         or fields["siggpg"] is not None
         or fields["sigpgp"] is not None
+        or bool(result.is_head_only_v6_signed)
     )
     result.is_ima_signed = filesignatures is not None
 

--- a/rpm_head_signing/insert_signature.py
+++ b/rpm_head_signing/insert_signature.py
@@ -47,6 +47,8 @@ def insert_signature(
         # Add OPENGPG (v6) Header record
         with open(sig_v6_path, "rb") as sigfile:
             rpm_v6_signature = sigfile.read()
+        rpm_v6_signature = base64.b64encode(rpm_v6_signature)
+        rpm_v6_signature = rpm_v6_signature.decode("utf-8")
     else:
         rpm_v6_signature = None
 

--- a/rpm_head_signing/insertlib.c
+++ b/rpm_head_signing/insertlib.c
@@ -415,7 +415,7 @@ insert_signatures(PyObject *self, PyObject *args)
         goto out;
     }
 
-    if (signature == NULL && ima_lookup == NULL) {
+    if (signature == NULL && ima_lookup == NULL && signature_v6 == NULL) {
         PyErr_SetString(PyExc_Exception, "No signature or ima_lookup provided");
         goto out;
     }
@@ -490,7 +490,7 @@ insert_signatures(PyObject *self, PyObject *args)
         sigtd_v6->type = RPM_STRING_ARRAY_TYPE;
         sigtd_v6->count = 1;
         sigtd_v6->data = arr;
-        sigtd_v6->flags = RPMTD_ALLOCED|RPMTD_PTR_ALLOCED;
+        sigtd_v6->flags = RPMTD_ALLOCED;
         sigtd_v6->ix = -1;
         sigtd_v6->size = 0;
 

--- a/test.py
+++ b/test.py
@@ -1,5 +1,6 @@
 from tempfile import mkdtemp
 from shutil import rmtree, copy
+import base64
 import os
 import os.path
 import subprocess
@@ -20,9 +21,11 @@ if rpm_version[0] < 4:
     raise Exception("RPM version %s is not major version 4" % (rpm_version,))
 header_msg = b"Header OpenPGP V3 RSA"
 check_digest = "SHA256"
+SUPPORTS_V6_HDR = True
 if rpm_version[0] < 6:
     check_digest = "SHA1"
     header_msg = b"Header V3 RSA"
+    SUPPORTS_V6_HDR = False
 
 
 class TestRpmHeadSigning(unittest.TestCase):
@@ -159,6 +162,64 @@ class TestRpmHeadSigning(unittest.TestCase):
             self.assertTrue(result.is_head_only_signed)
             self.assertTrue(result.is_signed)
             self.assertFalse(result.is_ima_signed)
+
+    def test_insert_no_ima_v6(self):
+        self._add_gpg_key("gpgkey.asc")
+        for pkg in self.pkg_numbers:
+            copy(
+                os.path.join(self.asset_dir, "testpkg-%s.rpm" % pkg),
+                os.path.join(self.tmpdir, "testpkg-%s.rpm" % pkg),
+            )
+            res = subprocess.check_output(
+                [
+                    "rpm",
+                    "--dbpath",
+                    self.tmpdir,
+                    "-Kv",
+                    os.path.join(self.tmpdir, "testpkg-%s.rpm" % pkg),
+                ],
+            )
+            self.assertTrue(f"{check_digest} digest: OK".encode("utf8") in res)
+            self.assertFalse(header_msg in res)
+            rpm_head_signing.insert_signature(
+                os.path.join(self.tmpdir, "testpkg-%s.rpm" % pkg),
+                None,
+                sig_v6_path=os.path.join(
+                    self.asset_dir, "testpkg-%s.rpm.hdr.sig" % pkg
+                ),
+            )
+            res = subprocess.check_output(
+                [
+                    "rpm",
+                    "--dbpath",
+                    self.tmpdir,
+                    "-Kv",
+                    os.path.join(self.tmpdir, "testpkg-%s.rpm" % pkg),
+                ],
+            )
+            self.assertTrue(f"{check_digest} digest: OK".encode("utf-8") in res)
+
+            if not SUPPORTS_V6_HDR:
+                # Continue to the next package
+                # This means we don't validate the signature, but at least we ensure the inserting itself doesn't fail.
+                continue
+
+            self.assertTrue(header_msg in res)
+            self.assertTrue(b"15f712be: ok" in res.lower())
+
+            result = rpm_head_signing.determine_rpm_status(
+                os.path.join(self.tmpdir, "testpkg-%s.rpm" % pkg)
+            )
+            self.assertTrue(result.is_head_only_signable)
+            self.assertTrue(result.is_head_only_v6_signed)
+            self.assertTrue(result.is_signed)
+            self.assertFalse(result.is_ima_signed)
+
+        if not SUPPORTS_V6_HDR:
+            # We want to mark the overall test as skipped, even if we did execute some things
+            raise unittest.SkipTest(
+                "Skipping v6 test",
+            )
 
     def test_insert_ima_presigned(self):
         def insert_cb(pkg):


### PR DESCRIPTION
Insertlib assumed the called would do base64 encoding, but that wasn't actually done.
This ensure that's done, and adds a test.